### PR TITLE
Add UK consumer prices visualization chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
             skills: ["Frontend", "Backend", "Full-stack", "API",
                 "Database", "DevOps", "CI/CD", "Testing", "AI/ML",
                 "Azure", "NoSQL", "MongoDB", "CosmosDB",
-                "Microservice Architecture", "Photoshop"],
+                "Microservice Architecture", "Photoshop", "Data Visualisation"],
 
             types: ["Open Source", "Personal", "Academic",
                 "Duct-Tape Utility", "Silly", "Quick Idea",

--- a/projects.json
+++ b/projects.json
@@ -353,6 +353,28 @@
     "thumb": "🎬❓"
   },
   {
+    "id": "uk-prices-chart",
+    "title": "UK Consumer Prices by Category",
+    "description": "Cumulative percentage change in UK consumer prices by category since 2005, based on ONS CPI data. Each line tracks how much prices in a given sector have risen or fallen relative to a common starting point.",
+    "languages": [
+      "HTML",
+      "CSS",
+      "JavaScript"
+    ],
+    "skills": [
+      "Frontend",
+      "Data Visualisation"
+    ],
+    "types": [
+      "Vibe-Coded",
+      "Quick Idea"
+    ],
+    "links": {
+      "demo": "https://jack-sleath.github.io/uk-prices-chart/index.html"
+    },
+    "thumb": "📈🇬🇧"
+  },
+  {
     "id": "bingo-board",
     "title": "JSON Bingo Board",
     "description": "A Bingo card that loads the squares up based on a JSON String Array.",

--- a/projects.json
+++ b/projects.json
@@ -234,7 +234,8 @@
     ],
     "skills": [
       "Frontend",
-      "Photoshop"
+      "Photoshop",
+      "Data Visualisation"
     ],
     "types": [
       "Academic",

--- a/uk-prices-chart/index.html
+++ b/uk-prices-chart/index.html
@@ -1,0 +1,444 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>UK Consumer Price Changes by Category</title>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --bg: #FAFAF7;
+    --card-bg: #FFFFFF;
+    --text: #1A1A18;
+    --text-muted: #6B6B65;
+    --text-hint: #9C9C95;
+    --border: rgba(0,0,0,0.08);
+    --accent: #A32D2D;
+    --tab-active-bg: #1A1A18;
+    --tab-active-text: #FAFAF7;
+    --tab-bg: transparent;
+    --tab-text: #6B6B65;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #141413;
+      --card-bg: #1E1E1C;
+      --text: #EAEAE6;
+      --text-muted: #A0A098;
+      --text-hint: #6B6B65;
+      --border: rgba(255,255,255,0.08);
+      --accent: #E24B4A;
+      --tab-active-bg: #EAEAE6;
+      --tab-active-text: #141413;
+      --tab-bg: transparent;
+      --tab-text: #A0A098;
+    }
+  }
+
+  body {
+    font-family: 'DM Sans', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    padding: 2rem 1rem;
+  }
+
+  .container {
+    max-width: 960px;
+    margin: 0 auto;
+  }
+
+  header {
+    margin-bottom: 2.5rem;
+  }
+
+  header h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(1.8rem, 4vw, 2.6rem);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1.15;
+    margin-bottom: 0.5rem;
+  }
+
+  header h1 span {
+    color: var(--accent);
+  }
+
+  header p {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    max-width: 560px;
+    line-height: 1.6;
+  }
+
+  .tabs {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 1.5rem;
+  }
+
+  .tab {
+    padding: 8px 18px;
+    border-radius: 100px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    border: 1px solid var(--border);
+    background: var(--tab-bg);
+    color: var(--tab-text);
+    transition: all 0.2s ease;
+    user-select: none;
+  }
+
+  .tab:hover { border-color: var(--text-muted); }
+
+  .tab.active {
+    background: var(--tab-active-bg);
+    color: var(--tab-active-text);
+    border-color: transparent;
+  }
+
+  .card {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .chart-header {
+    margin-bottom: 1rem;
+  }
+
+  .chart-header h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+  }
+
+  .chart-header p {
+    font-size: 0.8rem;
+    color: var(--text-hint);
+  }
+
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+    margin-bottom: 1rem;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    cursor: pointer;
+    transition: opacity 0.2s;
+    user-select: none;
+  }
+
+  .legend-item:hover { opacity: 0.7; }
+
+  .legend-item.hidden { opacity: 0.3; text-decoration: line-through; }
+
+  .legend-swatch {
+    width: 14px;
+    height: 3px;
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+
+  .chart-wrap {
+    position: relative;
+    width: 100%;
+    height: 400px;
+  }
+
+  .chart-section { display: none; }
+  .chart-section.active { display: block; }
+
+  .source {
+    font-size: 0.7rem;
+    color: var(--text-hint);
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--border);
+  }
+
+  .callout-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 12px;
+    margin-bottom: 1.5rem;
+  }
+
+  .callout {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1rem 1.15rem;
+  }
+
+  .callout-label {
+    font-size: 0.72rem;
+    color: var(--text-hint);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 4px;
+  }
+
+  .callout-value {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.5rem;
+    font-weight: 700;
+  }
+
+  .callout-sub {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-top: 2px;
+  }
+
+  .up { color: #A32D2D; }
+  .down { color: #0F6E56; }
+
+  footer {
+    text-align: center;
+    font-size: 0.75rem;
+    color: var(--text-hint);
+    margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+  }
+
+  @media (max-width: 600px) {
+    .chart-wrap { height: 300px; }
+    .card { padding: 1rem; }
+    .callout-row { grid-template-columns: repeat(2, 1fr); }
+  }
+</style>
+</head>
+<body>
+
+<div class="container">
+  <header>
+    <h1>How UK prices have <span>really</span> changed</h1>
+    <p>Not all prices move together. Education and tobacco have surged far ahead of overall inflation, while clothing and communications have barely budged. Explore two decades of CPI data by category.</p>
+  </header>
+
+  <div class="callout-row">
+    <div class="callout">
+      <div class="callout-label">Biggest riser</div>
+      <div class="callout-value up">+165%</div>
+      <div class="callout-sub">Education since 2005</div>
+    </div>
+    <div class="callout">
+      <div class="callout-label">Overall CPI</div>
+      <div class="callout-value">+64%</div>
+      <div class="callout-sub">All items since 2005</div>
+    </div>
+    <div class="callout">
+      <div class="callout-label">Least change</div>
+      <div class="callout-value down">-0.5%</div>
+      <div class="callout-sub">Communication since 2005</div>
+    </div>
+    <div class="callout">
+      <div class="callout-label">Current CPI</div>
+      <div class="callout-value">3.0%</div>
+      <div class="callout-sub">Feb 2026 (YoY)</div>
+    </div>
+  </div>
+
+  <div class="tabs">
+    <div class="tab active" data-tab="cumulative">Cumulative change</div>
+    <div class="tab" data-tab="yoy">Year-on-year</div>
+  </div>
+
+  <div class="card">
+    <div id="section-cumulative" class="chart-section active">
+      <div class="chart-header">
+        <h2>Cumulative price change since 2005</h2>
+        <p>CPI index by COICOP division, rebased so 2005 = 0%</p>
+      </div>
+      <div class="legend" id="legend-cumulative"></div>
+      <div class="chart-wrap"><canvas id="chartCumulative"></canvas></div>
+    </div>
+
+    <div id="section-yoy" class="chart-section">
+      <div class="chart-header">
+        <h2>Year-on-year % change</h2>
+        <p>Annual percentage change in CPI index, January to January</p>
+      </div>
+      <div class="legend" id="legend-yoy"></div>
+      <div class="chart-wrap"><canvas id="chartYoY"></canvas></div>
+    </div>
+
+    <div class="source">Source: ONS MM23 — CPI indices by COICOP division (2015 = 100). Approximate values based on published data.</div>
+  </div>
+
+  <footer>
+    Data from the Office for National Statistics. Visualisation built with Chart.js.
+  </footer>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js"></script>
+<script>
+const allYears = ['2005','2006','2007','2008','2009','2010','2011','2012','2013','2014','2015','2016','2017','2018','2019','2020','2021','2022','2023','2024','2025'];
+const yoyYears = allYears.slice(1);
+
+const raw = {
+  'Education':          [56.2,58.5,61.5,65.3,68.8,72.4,79.4,85.8,90.7,95.5,100.0,104.0,108.1,112.0,116.8,121.2,123.3,126.5,133.2,141.0,149.0],
+  'Alcohol & tobacco':  [71.6,73.0,74.8,78.0,81.8,85.7,91.7,96.7,99.3,101.1,100.0,103.5,107.5,112.1,116.4,120.3,124.1,127.5,133.6,139.4,145.0],
+  'Housing & utilities':[72.9,76.5,79.4,84.8,86.3,89.5,95.0,99.1,101.7,102.3,100.0,97.5,99.2,101.8,103.2,103.8,105.6,117.5,127.3,125.5,130.0],
+  'Food & drink':       [76.0,78.0,81.5,88.4,92.5,93.2,98.2,101.8,103.4,102.4,100.0,99.2,100.6,102.5,103.8,105.1,105.5,112.2,129.2,131.5,136.5],
+  'All items':          [80.2,81.8,83.6,86.7,88.6,91.5,95.4,98.1,100.6,102.0,100.0,100.6,103.3,105.9,107.8,108.9,109.8,116.5,125.6,128.0,131.8],
+  'Restaurants & hotels':[77.8,79.8,82.1,85.1,87.4,89.8,93.2,96.0,98.0,99.4,100.0,102.1,104.8,107.6,110.2,111.8,111.3,118.5,128.9,136.0,141.2],
+  'Health':             [82.5,83.8,85.3,87.4,89.6,91.7,94.2,96.1,97.6,98.8,100.0,101.3,103.2,105.1,106.8,108.5,110.3,113.1,119.4,125.0,129.0],
+  'Transport':          [79.0,81.5,84.0,89.5,86.0,91.5,98.2,101.5,100.8,101.0,100.0,99.2,102.5,105.8,106.5,103.5,105.8,115.2,118.5,118.0,121.5],
+  'Recreation & culture':[95.0,95.5,95.0,96.3,97.8,99.3,100.5,101.0,101.2,100.8,100.0,101.2,102.0,103.0,103.5,104.2,104.8,107.2,113.5,116.5,119.5],
+  'Clothing & footwear':[107.0,103.5,100.5,98.5,96.0,98.5,101.8,103.0,103.5,102.0,100.0,97.2,96.5,96.8,97.0,97.8,98.0,101.5,107.2,109.0,109.5],
+  'Communication':      [107.5,107.0,106.5,106.0,105.0,104.0,104.8,105.5,104.0,102.5,100.0,100.5,100.0,100.5,99.2,99.8,98.5,100.2,107.0,108.5,107.0],
+  'Furniture & household':[95.5,95.8,96.5,98.5,99.5,100.2,102.0,102.8,102.2,101.2,100.0,100.8,101.5,102.0,102.5,103.5,105.2,112.0,118.5,118.0,118.5]
+};
+
+const palette = {
+  'Education':          '#A32D2D',
+  'Alcohol & tobacco':  '#E24B4A',
+  'Housing & utilities':'#D85A30',
+  'Food & drink':       '#BA7517',
+  'All items':          '#888780',
+  'Restaurants & hotels':'#639922',
+  'Health':             '#1D9E75',
+  'Transport':          '#378ADD',
+  'Recreation & culture':'#534AB7',
+  'Clothing & footwear':'#D4537E',
+  'Communication':      '#185FA5',
+  'Furniture & household':'#0F6E56'
+};
+
+function rebase(arr) {
+  const b = arr[0];
+  return arr.map(v => Math.round(((v - b) / b) * 1000) / 10);
+}
+
+function yoy(arr) {
+  const out = [];
+  for (let i = 1; i < arr.length; i++) out.push(Math.round(((arr[i] - arr[i-1]) / arr[i-1]) * 1000) / 10);
+  return out;
+}
+
+const isDark = matchMedia('(prefers-color-scheme: dark)').matches;
+const gridColor = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.05)';
+const tickColor = isDark ? 'rgba(255,255,255,0.45)' : 'rgba(0,0,0,0.4)';
+const zeroColor = isDark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.12)';
+
+function makeDatasets(transformFn) {
+  return Object.entries(raw).map(([name, vals]) => ({
+    label: name,
+    data: transformFn(vals),
+    borderColor: palette[name],
+    borderWidth: name === 'All items' ? 3 : 1.5,
+    pointRadius: 0,
+    pointHoverRadius: 5,
+    pointHoverBackgroundColor: palette[name],
+    tension: 0.35,
+    borderDash: name === 'All items' ? [6, 3] : [],
+    fill: false,
+    hidden: false,
+    order: name === 'All items' ? 0 : 1
+  }));
+}
+
+function buildLegend(containerId, chart) {
+  const el = document.getElementById(containerId);
+  el.innerHTML = '';
+  chart.data.datasets.forEach((ds, i) => {
+    const item = document.createElement('span');
+    item.className = 'legend-item';
+    item.innerHTML = `<span class="legend-swatch" style="background:${ds.borderColor};${ds.borderDash.length ? 'background:repeating-linear-gradient(90deg,'+ds.borderColor+' 0,'+ds.borderColor+' 4px,transparent 4px,transparent 7px)' : ''}"></span>${ds.label}`;
+    item.addEventListener('click', () => {
+      const meta = chart.getDatasetMeta(i);
+      meta.hidden = !meta.hidden;
+      item.classList.toggle('hidden', meta.hidden);
+      chart.update();
+    });
+    el.appendChild(item);
+  });
+}
+
+const sharedOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  animation: { duration: 600, easing: 'easeOutQuart' },
+  interaction: { mode: 'index', intersect: false },
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      backgroundColor: isDark ? '#2A2A28' : '#fff',
+      titleColor: isDark ? '#EAEAE6' : '#1A1A18',
+      bodyColor: isDark ? '#A0A098' : '#6B6B65',
+      borderColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
+      borderWidth: 1,
+      padding: 12,
+      cornerRadius: 8,
+      titleFont: { family: "'DM Sans'", weight: '600', size: 13 },
+      bodyFont: { family: "'DM Sans'", size: 12 },
+      itemSort: (a, b) => b.parsed.y - a.parsed.y,
+      callbacks: {
+        label: ctx => {
+          if (ctx.dataset.hidden) return null;
+          const v = ctx.parsed.y;
+          return ` ${ctx.dataset.label}: ${v > 0 ? '+' : ''}${v.toFixed(1)}%`;
+        }
+      }
+    }
+  },
+  scales: {
+    x: {
+      grid: { display: false },
+      border: { display: false },
+      ticks: { color: tickColor, font: { family: "'DM Sans'", size: 11 }, maxRotation: 0, autoSkip: true, maxTicksLimit: 11 }
+    },
+    y: {
+      grid: { color: ctx => ctx.tick.value === 0 ? zeroColor : gridColor, lineWidth: ctx => ctx.tick.value === 0 ? 1.5 : 0.5 },
+      border: { display: false },
+      ticks: { color: tickColor, font: { family: "'DM Sans'", size: 11 }, callback: v => (v > 0 ? '+' : '') + v + '%' }
+    }
+  }
+};
+
+const chartCum = new Chart(document.getElementById('chartCumulative'), {
+  type: 'line',
+  data: { labels: allYears, datasets: makeDatasets(rebase) },
+  options: { ...sharedOptions, scales: { ...sharedOptions.scales, y: { ...sharedOptions.scales.y, min: -10, suggestedMax: 100 } } }
+});
+buildLegend('legend-cumulative', chartCum);
+
+const chartYoY = new Chart(document.getElementById('chartYoY'), {
+  type: 'line',
+  data: { labels: yoyYears, datasets: makeDatasets(yoy) },
+  options: { ...sharedOptions }
+});
+buildLegend('legend-yoy', chartYoY);
+
+document.querySelectorAll('.tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+    document.querySelectorAll('.chart-section').forEach(s => s.classList.remove('active'));
+    tab.classList.add('active');
+    document.getElementById('section-' + tab.dataset.tab).classList.add('active');
+    if (tab.dataset.tab === 'cumulative') chartCum.resize();
+    else chartYoY.resize();
+  });
+});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
Added a new interactive data visualization project showcasing UK consumer price changes by category since 2005, based on ONS CPI data. The visualization allows users to explore cumulative price changes and year-on-year percentage changes across 12 product categories.

## Changes
- **New project**: `uk-prices-chart/index.html` — A standalone HTML page with embedded CSS and JavaScript that visualizes UK CPI data
  - Displays two chart views: cumulative change since 2005 and year-on-year percentage changes
  - Interactive legend allowing users to toggle category visibility
  - Responsive design with light/dark mode support using CSS custom properties
  - Key statistics callouts showing education (+165%), overall CPI (+64%), communication (-0.5%), and current inflation (3.0%)
  - Built with Chart.js for line chart rendering
  
- **Updated**: `projects.json` — Added project metadata entry with:
  - Project ID, title, and description
  - Language tags (HTML, CSS, JavaScript)
  - Skill categories (Frontend, Data Visualisation)
  - Project type tags (Vibe-Coded, Quick Idea)
  - Demo link to the visualization

## Implementation Details
- Uses Chart.js 4.4.1 for chart rendering with custom styling
- Data includes 21 years (2005–2025) across 12 COICOP categories plus overall CPI
- Implements data transformation functions: `rebase()` for cumulative change and `yoy()` for year-on-year calculations
- Responsive grid layout for callout statistics (4 columns on desktop, 2 on mobile)
- Tab-based navigation between chart views with smooth transitions
- Accessible color palette with dark mode support via `prefers-color-scheme` media query
- Source attribution to ONS MM23 CPI indices

https://claude.ai/code/session_01Frjzqr13niQmwsJxX1keWL