### PR TITLE
Add 3x3 option to bingo generator

### DIFF
--- a/bingo/index.html
+++ b/bingo/index.html
@@ -16,7 +16,8 @@
             <textarea id="items" rows="4" placeholder='Enter items as JSON array, e.g. ["A","B","C", ...]'></textarea>
             <input type="file" id="fileInput" accept=".json,application/json">
             <div class="actions">
-                <button id="generate">Generate Bingo</button>
+                <button id="generate3">Generate 3x3</button>
+                <button id="generate">Generate 5x5</button>
             </div>
         </section>
         <section class="board-wrap">

--- a/bingo/script.js
+++ b/bingo/script.js
@@ -32,44 +32,47 @@ if (fileInput) {
     });
 }
 
-// Generate bingo board from textarea JSON array
-const generateBtn = document.getElementById('generate');
-if (generateBtn) {
-    generateBtn.addEventListener("click", () => {
-        const input = document.getElementById("items").value;
-        let items;
-        try {
-            items = JSON.parse(input);
-            if (!Array.isArray(items)) throw new Error('Not an array');
-        } catch (err) {
-            alert("Please enter a valid JSON array of strings.");
-            return;
+// Generate bingo board of a given size from textarea JSON array
+function generateBoard(size) {
+    const input = document.getElementById("items").value;
+    let items;
+    try {
+        items = JSON.parse(input);
+        if (!Array.isArray(items)) throw new Error('Not an array');
+    } catch (err) {
+        alert("Please enter a valid JSON array of strings.");
+        return;
+    }
+
+    const total = size * size;
+    const pool = items.slice();
+    while (pool.length < total) pool.push("Free Square");
+
+    const boardItems = shuffle(pool).slice(0, total);
+    const table = document.getElementById("bingo");
+    if (!table) return;
+    table.innerHTML = "";
+    table.dataset.size = String(size);
+
+    for (let r = 0; r < size; r++) {
+        const row = table.insertRow();
+        for (let c = 0; c < size; c++) {
+            const cell = row.insertCell();
+            const content = document.createElement('div');
+            content.textContent = boardItems[r * size + c];
+            cell.appendChild(content);
+            cell.addEventListener("click", () => {
+                cell.classList.toggle("marked");
+            });
         }
+    }
 
-        // Ensure there are at least 25 items, pad with "Free Square" if needed
-        const pool = items.slice();
-        while (pool.length < 25) pool.push("Free Square");
-
-        const boardItems = shuffle(pool).slice(0, 25);
-        const table = document.getElementById("bingo");
-        if (!table) return;
-        table.innerHTML = "";
-
-        for (let r = 0; r < 5; r++) {
-            const row = table.insertRow();
-            for (let c = 0; c < 5; c++) {
-                const cell = row.insertCell();
-                const content = document.createElement('div');
-                content.textContent = boardItems[r * 5 + c];
-                cell.appendChild(content);
-                cell.addEventListener("click", () => {
-                    cell.classList.toggle("marked");
-                });
-            }
-        }
-
-        // Hide the input controls so only the board shows
-        const controls = document.getElementById('controls');
-        if (controls) controls.style.display = 'none';
-    });
+    const controls = document.getElementById('controls');
+    if (controls) controls.style.display = 'none';
 }
+
+const generateBtn = document.getElementById('generate');
+if (generateBtn) generateBtn.addEventListener("click", () => generateBoard(5));
+
+const generate3Btn = document.getElementById('generate3');
+if (generate3Btn) generate3Btn.addEventListener("click", () => generateBoard(3));

--- a/bingo/style.css
+++ b/bingo/style.css
@@ -120,10 +120,12 @@ header {
 .actions {
     display: flex;
     justify-content: flex-end;
+    gap: 0.5rem;
     margin-top: 0.6rem
 }
 
-button#generate {
+button#generate,
+button#generate3 {
     background: var(--accent);
     border: none;
     color: var(--accent-contrast);
@@ -133,9 +135,16 @@ button#generate {
     cursor: pointer
 }
 
-    button#generate:active {
+    button#generate:active,
+    button#generate3:active {
         transform: translateY(1px)
     }
+
+button#generate3 {
+    background: transparent;
+    color: var(--text);
+    border: 1px solid var(--border)
+}
 
 .board-wrap {
     display: flex;
@@ -156,6 +165,11 @@ button#generate {
         position: relative;
         border: 1px solid var(--cell-border);
         background: var(--cell-bg)
+    }
+
+    #bingo[data-size="3"] td {
+        width: calc(100% / 3);
+        padding-top: calc(100% / 3)
     }
 
         #bingo td > div {
@@ -190,8 +204,9 @@ button#generate {
         font-size: 1.25rem
     }
 
-    button#generate {
-        width: 100%
+    button#generate,
+    button#generate3 {
+        flex: 1
     }
 
     .actions {


### PR DESCRIPTION
Adds a second generate button so users can produce a smaller 3x3 board
alongside the existing 5x5. Cell sizing tracks the board size via a
data-size attribute, and the board generator is now size-parameterised.